### PR TITLE
add ToSerializable method

### DIFF
--- a/Jos.ContentJson/Extensions/ContentAreaExtensions.cs
+++ b/Jos.ContentJson/Extensions/ContentAreaExtensions.cs
@@ -11,9 +11,14 @@ namespace Jos.ContentJson.Extensions
     {
         public static string ToJson(this ContentArea contentArea, bool wrapItems = true)
         {
-            var structuredData = GetStructuredData(contentArea, wrapItems);
+            var structuredData = ToSerializable(contentArea, wrapItems);
             var json = JsonConvert.SerializeObject(structuredData);
             return json;
+        }
+
+        public static object ToSerializable(this ContentArea contentArea, bool wrapItems = true)
+        {
+            return GetStructuredData(contentArea, wrapItems);
         }
 
         /// <summary>

--- a/Jos.ContentJson/Extensions/ContentDataExtensions.cs
+++ b/Jos.ContentJson/Extensions/ContentDataExtensions.cs
@@ -21,9 +21,14 @@ namespace Jos.ContentJson.Extensions
 
         public static string ToJson(this IContentData contentData)
         {
-            var propertiesDict = GetStructuredDictionary(contentData);
+            var propertiesDict = ToSerializable(contentData);
             var json = JsonConvert.SerializeObject(propertiesDict);
             return json;
+        }
+
+        public static object ToSerializable(this IContentData contentData)
+        {
+            return GetStructuredDictionary(contentData);
         }
 
         public static string GetJsonKey(this IContentData contentData)

--- a/Jos.ContentJson/Extensions/LinkItemCollectionExtensions.cs
+++ b/Jos.ContentJson/Extensions/LinkItemCollectionExtensions.cs
@@ -9,9 +9,13 @@ namespace Jos.ContentJson.Extensions
     {
         public static string ToJson(this LinkItemCollection linkItemCollection)
         {
-            var structuredData = GetStructuredData(linkItemCollection);
-            var json = JsonConvert.SerializeObject(structuredData);
+            var json = JsonConvert.SerializeObject(ToSerializable(linkItemCollection));
             return json;
+        }
+
+        public static object ToSerializable(this LinkItemCollection linkItemCollection)
+        {
+            return GetStructuredData(linkItemCollection);
         }
 
         public static IEnumerable<LinkItemDto> GetStructuredData(this LinkItemCollection linkItemCollection)


### PR DESCRIPTION
This would allow the user to get their hands on the serializable object that is created, just before calling `JsonConvert.SerializeObject`. This is useful for when we need the object itself instead of the serialized string. For example, when using React.NET with server-side rendering, one can do this:

```cshtml
@using Jos.ContentJson.Extensions
@model Models.MyModel

@Html.React("MyComponent", Model.ToSerializable())
```

Although it's already possible to do that by calling either `GetStructuredDictionary` or `GetStructuredData`, this PR makes it uniform with the same method name regardless of the type. Also, the return type of `GetStructuredDictionary` is technically a `Dictionary<string, object>`, not an `object`.