### PR TITLE
Selected Options Only Attribute for string properties

### DIFF
--- a/src/JOS.ContentSerializer.Tests/Pages/StringPropertyHandlerPage.cs
+++ b/src/JOS.ContentSerializer.Tests/Pages/StringPropertyHandlerPage.cs
@@ -3,6 +3,7 @@ using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.DataAnnotations;
 using EPiServer.Shell.ObjectEditing;
+using JOS.ContentSerializer.Attributes;
 
 namespace JOS.ContentSerializer.Tests.Pages
 {
@@ -22,5 +23,21 @@ namespace JOS.ContentSerializer.Tests.Pages
 
         [SelectMany(SelectionFactoryType = typeof(SelectionFactory))]
         public virtual string SelectMany { get; set; }
+
+        [SelectOne(SelectionFactoryType = typeof(SelectionFactory))]
+        [ContentSerializerSelectedOptionsOnly]
+        public virtual string SelectedOnlyOne { get; set; }
+
+        [SelectMany(SelectionFactoryType = typeof(SelectionFactory))]
+        [ContentSerializerSelectedOptionsOnly]
+        public virtual string SelectedOnlyMany { get; set; }
+
+        [SelectOne(SelectionFactoryType = typeof(SelectionFactory))]
+        [ContentSerializerSelectedOptionsOnly(SelectedValueOnly = true)]
+        public virtual string SelectedOnlyValueOnlyOne { get; set; }
+
+        [SelectMany(SelectionFactoryType = typeof(SelectionFactory))]
+        [ContentSerializerSelectedOptionsOnly(SelectedValueOnly = true)]
+        public virtual string SelectedOnlyValueOnlyMany { get; set; }
     }
 }

--- a/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/StringPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/StringPropertyHandlerTests.cs
@@ -43,12 +43,81 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
                 SelectOne = "option3"
             };
 
-            var result = (List<SelectOption>)this._sut.Handle(page.SelectOne,
+            var result = (IEnumerable<SelectOption>)this._sut.Handle(page.SelectOne,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectOne)),
                 page);
 
             result.ShouldContain(x => x.Selected && x.Value.Equals("option3") && x.Text.Equals("Option 3"));
             result.Count(x => x.Selected).ShouldBe(1);
+        }
+
+        [Fact]
+        public void GivenStringPropertyWithSelectOneAndSelectedOptionsOnlyAttribute_WhenHandle_ThenReturnsCorrectValue()
+        {
+            var page = new StringPropertyHandlerPage
+            {
+                SelectedOnlyOne = "option4"
+            };
+
+            var result = (IEnumerable<SelectOption>)this._sut.Handle(page.SelectedOnlyOne,
+                page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectedOnlyOne)),
+                page);
+
+            result.ShouldContain(x => x.Selected && x.Value.Equals("option4") && x.Text.Equals("Option 4"));
+            result.Count(x => x.Selected).ShouldBe(1);
+            result.Count().ShouldBe(1);
+        }
+
+        [Fact]
+        public void GivenStringPropertyWithSelectOneAndSelectedOptionOnlysAttribute_ValueOnly_WhenHandle_ThenReturnsCorrectValue()
+        {
+            var page = new StringPropertyHandlerPage
+            {
+                SelectedOnlyValueOnlyOne = "option5"
+            };
+
+            var result = (string)this._sut.Handle(page.SelectedOnlyValueOnlyOne,
+                page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectedOnlyValueOnlyOne)),
+                page);
+
+            result.ShouldBe("option5");
+        }
+
+        [Fact]
+        public void GivenStringPropertyWithSelectManyAndSelectedOptionsOnlyAttribute_WhenHandle_ThenReturnsCorrectValue()
+        {
+            var page = new StringPropertyHandlerPage
+            {
+                SelectedOnlyMany = "option5,option6,option7"
+            };
+
+            var result = (IEnumerable<SelectOption>)this._sut.Handle(page.SelectedOnlyMany,
+                page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectedOnlyMany)),
+                page);
+
+            result.ShouldContain(x => x.Selected && x.Value.Equals("option5") && x.Text.Equals("Option 5"));
+            result.ShouldContain(x => x.Selected && x.Value.Equals("option6") && x.Text.Equals("Option 6"));
+            result.ShouldContain(x => x.Selected && x.Value.Equals("option7") && x.Text.Equals("Option 7"));
+            result.Count(x => x.Selected).ShouldBe(3);
+            result.Count().ShouldBe(3);
+        }
+
+        [Fact]
+        public void GivenStringPropertyWithSelectManyAndSelectedOptionsOnlyAttribute_ValueOnly_WhenHandle_ThenReturnsCorrectValue()
+        {
+            var page = new StringPropertyHandlerPage
+            {
+                SelectedOnlyValueOnlyMany = "option5,option6,option7"
+            };
+
+            var result = (IEnumerable<string>)this._sut.Handle(page.SelectedOnlyValueOnlyMany,
+                page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectedOnlyValueOnlyMany)),
+                page);
+
+            result.ShouldContain(x => x == "option5");
+            result.ShouldContain(x => x == "option6");
+            result.ShouldContain(x => x == "option7");
+            result.Count().ShouldBe(3);
         }
 
         [Theory]
@@ -61,7 +130,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
                 SelectOne = selectOneValue
             };
 
-            var result = (List<SelectOption>)this._sut.Handle(page.SelectOne,
+            var result = (IEnumerable<SelectOption>)this._sut.Handle(page.SelectOne,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectOne)),
                 page);
 
@@ -76,7 +145,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
                 SelectMany = "option3,option4,option5"
             };
 
-            var result = (List<SelectOption>)this._sut.Handle(page.SelectMany,
+            var result = (IEnumerable<SelectOption>)this._sut.Handle(page.SelectMany,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectMany)),
                 page);
 
@@ -96,7 +165,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
                 SelectMany = selectManyValue
             };
 
-            var result = (List<SelectOption>)this._sut.Handle(page.SelectMany,
+            var result = (IEnumerable<SelectOption>)this._sut.Handle(page.SelectMany,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectOne)),
                 page);
 

--- a/src/JOS.ContentSerializer/Attributes/ContentSerializerSelectedOptionsOnlyAttribute.cs
+++ b/src/JOS.ContentSerializer/Attributes/ContentSerializerSelectedOptionsOnlyAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace JOS.ContentSerializer.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ContentSerializerSelectedOptionsOnlyAttribute : Attribute
+    {
+        public virtual bool SelectedValueOnly { get; set; }
+    }
+}

--- a/src/JOS.ContentSerializer/JOS.ContentSerializer.csproj
+++ b/src/JOS.ContentSerializer/JOS.ContentSerializer.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Attributes\ContentSerializerIgnoreAttribute.cs" />
     <Compile Include="Attributes\ContentSerializerIncludeAttribute.cs" />
     <Compile Include="Attributes\ContentSerializerPropertyHandlerAttribute.cs" />
+    <Compile Include="Attributes\ContentSerializerSelectedOptionsOnlyAttribute.cs" />
     <Compile Include="IContentDataExtensions.cs" />
     <Compile Include="Attributes\ContentSerializerNameAttribute.cs" />
     <Compile Include="ContentSerializerSettings.cs" />


### PR DESCRIPTION
Attribute to be used along with SelectOneAttribute or SelectManyAttribute so the StringPropertyHandler only returns the selected option(s).

If were only interested in the selected value(s) we don't need to handle:

`
"SelectionOptions": [
	{
		"Selected": true,
		"Text": "Option 1",
		"Value": "option1"
	},
	{
		"Selected": false,
		"Text": "Option 2",
		"Value": "option2"
	}
]
`

We get:
`
"SelectionOptions": [
	{
		"Selected": true,
		"Text": "Option 1",
		"Value": "option1"
	}
]
`

Or if the ValueOnly option is set:
`
"SelectionOptions": "option1"
`
