### PR TITLE
Fix/issue#22

### DIFF
--- a/src/JOS.ContentSerializer.Tests/ContentAreaPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ContentAreaPropertyHandlerTests.cs
@@ -13,19 +13,21 @@ namespace JOS.ContentSerializer.Tests
     public class ContentAreaPropertyHandlerTests
     {
         private readonly ContentAreaPropertyHandler _sut;
+        private IContentSerializerSettings _contentSerializerSettings;
 
         public ContentAreaPropertyHandlerTests()
         {
+            this._contentSerializerSettings = new ContentSerializerSettings();
             var contentLoader = Substitute.For<IContentLoader>();
             SetupContentLoader(contentLoader);
             var propertyManager = Substitute.For<IPropertyManager>();
-            this._sut = new ContentAreaPropertyHandler(contentLoader, propertyManager, new ContentSerializerSettings());
+            this._sut = new ContentAreaPropertyHandler(contentLoader, propertyManager);
         }
 
         [Fact]
         public void GivenNullContentArea_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, this._contentSerializerSettings);
 
             result.ShouldBeNull();
         }

--- a/src/JOS.ContentSerializer.Tests/ContentReferenceListPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ContentReferenceListPropertyHandlerTests.cs
@@ -19,13 +19,13 @@ namespace JOS.ContentSerializer.Tests
             this._urlHelper = Substitute.For<IUrlHelper>();
             this._contentSerializerSettings = Substitute.For<IContentSerializerSettings>();
             this._contentSerializerSettings.UrlSettings = new UrlSettings();
-            this._sut = new ContentReferenceListPropertyHandler(new ContentReferencePropertyHandler(this._urlHelper, this._contentSerializerSettings));
+            this._sut = new ContentReferenceListPropertyHandler(new ContentReferencePropertyHandler(this._urlHelper));
         }
 
         [Fact]
         public void GivenNullList_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, this._contentSerializerSettings);
 
             result.ShouldBeNull();
         }
@@ -35,7 +35,7 @@ namespace JOS.ContentSerializer.Tests
         {
             var contentReferences = Enumerable.Empty<ContentReference>();
 
-            var result = this._sut.Handle(contentReferences, null, null);
+            var result = this._sut.Handle(contentReferences, null, null, this._contentSerializerSettings);
 
             ((IEnumerable<object>)result).ShouldBeEmpty();
         }
@@ -53,7 +53,7 @@ namespace JOS.ContentSerializer.Tests
             this._urlHelper.ContentUrl(contentReference, this._contentSerializerSettings.UrlSettings)
                 .Returns($"{baseUrl}{prettyPath}");
 
-            var result = this._sut.Handle(contentReferences, null, null);
+            var result = this._sut.Handle(contentReferences, null, null, this._contentSerializerSettings);
             var items = ((IEnumerable<object>)result).Cast<string>().ToList();
 
             items.Count.ShouldBe(1);

--- a/src/JOS.ContentSerializer.Tests/ContentReferencePropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ContentReferencePropertyHandlerTests.cs
@@ -17,13 +17,13 @@ namespace JOS.ContentSerializer.Tests
             this._contentSerializerSettings = Substitute.For<IContentSerializerSettings>();
             this._contentSerializerSettings.UrlSettings = new UrlSettings();
             this._urlHelper = Substitute.For<IUrlHelper>();
-            this._sut = new ContentReferencePropertyHandler(this._urlHelper, this._contentSerializerSettings);
+            this._sut = new ContentReferencePropertyHandler(this._urlHelper);
         }
 
         [Fact]
         public void GivenNullContentReference_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, this._contentSerializerSettings);
 
             result.ShouldBeNull();
         }
@@ -31,7 +31,7 @@ namespace JOS.ContentSerializer.Tests
         [Fact]
         public void GivenEmptyContentReference_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(ContentReference.EmptyReference, null, null);
+            var result = this._sut.Handle(ContentReference.EmptyReference, null, null, this._contentSerializerSettings);
 
             result.ShouldBeNull();
         }
@@ -47,7 +47,7 @@ namespace JOS.ContentSerializer.Tests
             this._urlHelper.ContentUrl(contentReference, this._contentSerializerSettings.UrlSettings)
                 .Returns($"{baseUrl}{prettyPath}");
 
-            var result = this._sut.Handle(contentReference, null, null);
+            var result = this._sut.Handle(contentReference, null, null, this._contentSerializerSettings);
 
             result.ShouldBe($"{baseUrl}{prettyPath}");
         }
@@ -64,7 +64,7 @@ namespace JOS.ContentSerializer.Tests
             this._urlHelper.ContentUrl(Arg.Any<ContentReference>(), this._contentSerializerSettings.UrlSettings)
                 .Returns($"{baseUrl}{prettyPath}");
 
-            var result = this._sut.Handle(contentReference, null, null);
+            var result = this._sut.Handle(contentReference, null, null, this._contentSerializerSettings);
 
             result.ShouldBe(prettyPath);
         }

--- a/src/JOS.ContentSerializer.Tests/LinkItemCollectionPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/LinkItemCollectionPropertyHandlerTests.cs
@@ -22,13 +22,13 @@ namespace JOS.ContentSerializer.Tests
             this._contentSerializerSettings = Substitute.For<IContentSerializerSettings>();
             this._contentSerializerSettings.UrlSettings = new UrlSettings();
             this._urlHelper = Substitute.For<IUrlHelper>();
-            this._sut = new LinkItemCollectionPropertyHandler(this._urlHelper, this._contentSerializerSettings);
+            this._sut = new LinkItemCollectionPropertyHandler(this._urlHelper);
         }
 
         [Fact]
         public void GivenNullLinkItemCollection_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, this._contentSerializerSettings);
 
             result.ShouldBeNull();
         }
@@ -45,7 +45,7 @@ namespace JOS.ContentSerializer.Tests
                 Title = "any title"
             });
 
-            var result = ((IEnumerable<LinkItem>)this._sut.Handle(linkItemCollection, null, null)).ToList();
+            var result = ((IEnumerable<LinkItem>)this._sut.Handle(linkItemCollection, null, null, this._contentSerializerSettings)).ToList();
 
             result.Count.ShouldBe(1);
             result.ShouldContain(x => x.Href == value);
@@ -66,7 +66,7 @@ namespace JOS.ContentSerializer.Tests
                 Target = "_blank"
             });
 
-            var result = ((IEnumerable<LinkItem>)this._sut.Handle(linkItemCollection, null, null)).ToList();
+            var result = ((IEnumerable<LinkItem>)this._sut.Handle(linkItemCollection, null, null, this._contentSerializerSettings)).ToList();
 
             result.Count.ShouldBe(1);
             result.ShouldContain(x => x.Href == value);
@@ -94,7 +94,7 @@ namespace JOS.ContentSerializer.Tests
             });
             linkItemCollection.Add(linkItem);
 
-            var result = ((IEnumerable<LinkItem>)this._sut.Handle(linkItemCollection, null, null)).ToList();
+            var result = ((IEnumerable<LinkItem>)this._sut.Handle(linkItemCollection, null, null, this._contentSerializerSettings)).ToList();
 
             result.Count.ShouldBe(1);
             result.ShouldContain(x => x.Href == expected);
@@ -122,7 +122,7 @@ namespace JOS.ContentSerializer.Tests
             });
             linkItemCollection.Add(linkItem);
 
-            var result = ((IEnumerable<LinkItem>)this._sut.Handle(linkItemCollection, null, null)).ToList();
+            var result = ((IEnumerable<LinkItem>)this._sut.Handle(linkItemCollection, null, null, this._contentSerializerSettings)).ToList();
 
             result.Count.ShouldBe(1);
             result.ShouldContain(x => x.Href == expected);

--- a/src/JOS.ContentSerializer.Tests/PageTypePropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/PageTypePropertyHandlerTests.cs
@@ -17,7 +17,7 @@ namespace JOS.ContentSerializer.Tests
         [Fact]
         public void GivenNullPageType_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, null);
 
             result.ShouldBeNull();
         }
@@ -27,7 +27,7 @@ namespace JOS.ContentSerializer.Tests
         {
             var pageType = new PageType {Name = "anytype"};
 
-            var result = this._sut.Handle(pageType, null, null);
+            var result = this._sut.Handle(pageType, null, null, null);
 
             ((PageTypeModel)result).Name.ShouldBe(pageType.Name);
         }

--- a/src/JOS.ContentSerializer.Tests/PropertyManagerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/PropertyManagerTests.cs
@@ -129,7 +129,7 @@ namespace JOS.ContentSerializer.Tests
             urlHelper.ContentUrl(contentReference, Arg.Any<IUrlSettings>()).Returns(contentReferencePageUrl);
             serviceLocator.TryGetExistingInstance(typeof(IPropertyHandler<ContentReference>), out var _).Returns(x =>
             {
-                x[1] = new ContentReferencePropertyHandler(urlHelper, this._contentSerializerSettings);
+                x[1] = new ContentReferencePropertyHandler(urlHelper);
                 return true;
             });
             ServiceLocator.SetLocator(serviceLocator);
@@ -147,7 +147,7 @@ namespace JOS.ContentSerializer.Tests
             var serviceLocator = Substitute.For<IServiceLocator>();
             var urlHelper = Substitute.For<IUrlHelper>();
             var pageReferenceUrl = "https://josefottosson.se/";
-            var contentReferencePropertyHandler = new ContentReferencePropertyHandler(urlHelper, this._contentSerializerSettings);
+            var contentReferencePropertyHandler = new ContentReferencePropertyHandler(urlHelper);
             urlHelper.ContentUrl(pageReference, Arg.Any<IUrlSettings>()).Returns(pageReferenceUrl);
             serviceLocator.TryGetExistingInstance(typeof(IPropertyHandler<PageReference>), out var _).Returns(x =>
             {
@@ -169,7 +169,7 @@ namespace JOS.ContentSerializer.Tests
             var serviceLocator = Substitute.For<IServiceLocator>();
             serviceLocator.TryGetExistingInstance(typeof(IPropertyHandler<ContentArea>), out var _).Returns(x =>
             {
-                x[1] = new ContentAreaPropertyHandler(this._contentLoader, this._sut, this._contentSerializerSettings);
+                x[1] = new ContentAreaPropertyHandler(this._contentLoader, this._sut);
                 return true;
             });
             serviceLocator.TryGetExistingInstance(typeof(IPropertyHandler<string>), out var _).Returns(x =>
@@ -297,7 +297,7 @@ namespace JOS.ContentSerializer.Tests
             };
             contentArea.Count.Returns(items.Count);
             contentArea.FilteredItems.Returns(items);
-            
+
             return contentArea;
         }
     }

--- a/src/JOS.ContentSerializer.Tests/StringPropertyHandlerWithCustomSelectStrategiesTests.cs
+++ b/src/JOS.ContentSerializer.Tests/StringPropertyHandlerWithCustomSelectStrategiesTests.cs
@@ -30,7 +30,7 @@ namespace JOS.ContentSerializer.Tests
 
             var result = (SelectOption)this._sut.Handle(page.SelectedOnlyOne,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectedOnlyOne)),
-                page);
+                page, null);
 
             result.Selected.ShouldBeTrue();
             result.Text.ShouldBe("Option 4");
@@ -47,7 +47,7 @@ namespace JOS.ContentSerializer.Tests
 
             var result = (string)this._sut.Handle(page.SelectedOnlyValueOnlyOne,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectedOnlyValueOnlyOne)),
-                page);
+                page, null);
 
             result.ShouldBe("option5");
         }
@@ -62,7 +62,7 @@ namespace JOS.ContentSerializer.Tests
 
             var result = ((IEnumerable<SelectOption>)this._sut.Handle(page.SelectedOnlyMany,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectedOnlyMany)),
-                page)).ToList();
+                page, null)).ToList();
 
             result.ShouldContain(x => x.Selected && x.Value.Equals("option5") && x.Text.Equals("Option 5"));
             result.ShouldContain(x => x.Selected && x.Value.Equals("option6") && x.Text.Equals("Option 6"));
@@ -81,7 +81,7 @@ namespace JOS.ContentSerializer.Tests
 
             var result = ((IEnumerable<string>)this._sut.Handle(page.SelectedOnlyValueOnlyMany,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectedOnlyValueOnlyMany)),
-                page)).ToList();
+                page, null)).ToList();
 
             result.ShouldContain(x => x == "option5");
             result.ShouldContain(x => x == "option6");

--- a/src/JOS.ContentSerializer.Tests/UrlPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/UrlPropertyHandlerTests.cs
@@ -11,19 +11,19 @@ namespace JOS.ContentSerializer.Tests
         private readonly UrlPropertyHandler _sut;
         private readonly IUrlHelper _urlHelper;
         private IContentSerializerSettings _contentSerializerSettings;
-        
+
         public UrlPropertyHandlerTests()
         {
             this._contentSerializerSettings = Substitute.For<IContentSerializerSettings>();
             this._contentSerializerSettings.UrlSettings = new UrlSettings();
             this._urlHelper = Substitute.For<IUrlHelper>();
-            this._sut = new UrlPropertyHandler(this._urlHelper, this._contentSerializerSettings);
+            this._sut = new UrlPropertyHandler(this._urlHelper);
         }
 
         [Fact]
         public void GivenNullUrl_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, this._contentSerializerSettings);
 
             result.ShouldBeNull();
         }
@@ -34,7 +34,7 @@ namespace JOS.ContentSerializer.Tests
             var value = "mailto:mail@example.com";
             var url = new Url(value);
 
-            var result = this._sut.Handle(url, null, null);
+            var result = this._sut.Handle(url, null, null, this._contentSerializerSettings);
 
             result.ShouldBe(value);
         }
@@ -45,7 +45,7 @@ namespace JOS.ContentSerializer.Tests
             var value = "https://josef.guru/example/page?anyQueryString=true&anyOtherQuery";
             var url = new Url(value);
 
-            var result = this._sut.Handle(url, null, null);
+            var result = this._sut.Handle(url, null, null, this._contentSerializerSettings);
 
             result.ShouldBe(value);
         }
@@ -57,7 +57,7 @@ namespace JOS.ContentSerializer.Tests
             var value = "https://josef.guru/example/page?anyQueryString=true&anyOtherQuery";
             var url = new Url(value);
 
-            var result = this._sut.Handle(url, null, null);
+            var result = this._sut.Handle(url, null, null, this._contentSerializerSettings);
 
             result.ShouldBe(url.PathAndQuery);
         }
@@ -70,8 +70,8 @@ namespace JOS.ContentSerializer.Tests
             var value = "/link/d40d0056ede847d5a2f3b4a02778d15b.aspx";
             var url = new Url(value);
             this._urlHelper.ContentUrl(Arg.Any<Url>(), this._contentSerializerSettings.UrlSettings).Returns($"{siteUrl}{prettyPath}");
-         
-            var result = this._sut.Handle(url, null, null);
+
+            var result = this._sut.Handle(url, null, null, this._contentSerializerSettings);
 
             result.ShouldBe($"{siteUrl}{prettyPath}");
         }
@@ -85,7 +85,7 @@ namespace JOS.ContentSerializer.Tests
             this._contentSerializerSettings.UrlSettings.Returns(new UrlSettings { UseAbsoluteUrls = false });
             this._urlHelper.ContentUrl(Arg.Any<Url>(), this._contentSerializerSettings.UrlSettings).Returns(prettyPath);
 
-            var result = this._sut.Handle(url, null, null);
+            var result = this._sut.Handle(url, null, null, this._contentSerializerSettings);
 
             result.ShouldBe(prettyPath);
         }

--- a/src/JOS.ContentSerializer.Tests/ValueTypeListPropertyHandlers/DateTimeListPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypeListPropertyHandlers/DateTimeListPropertyHandlerTests.cs
@@ -19,7 +19,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         [Fact]
         public void GivenNullList_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, null);
 
             result.ShouldBeNull();
         }
@@ -27,7 +27,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         [Fact]
         public void GivenEmptyList_WhenHandle_ThenReturnsSameList()
         {
-            var result = this._sut.Handle(Enumerable.Empty<DateTime>(), null, null);
+            var result = this._sut.Handle(Enumerable.Empty<DateTime>(), null, null, null);
 
             ((IEnumerable<DateTime>)result).ShouldBeEmpty();
         }
@@ -39,7 +39,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
             var year3000 = new DateTime(3000, 1, 20);
             var items = new List<DateTime> { year2000, year3000};
 
-            var result = this._sut.Handle(items, null, null);
+            var result = this._sut.Handle(items, null, null, null);
 
             ((IEnumerable<DateTime>)result).ShouldContain(year2000);
             ((IEnumerable<DateTime>)result).ShouldContain(year3000);

--- a/src/JOS.ContentSerializer.Tests/ValueTypeListPropertyHandlers/DoubleListPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypeListPropertyHandlers/DoubleListPropertyHandlerTests.cs
@@ -18,7 +18,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         [Fact]
         public void GivenNullList_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, null);
 
             result.ShouldBeNull();
         }
@@ -26,7 +26,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         [Fact]
         public void GivenEmptyList_WhenHandle_ThenReturnsSameList()
         {
-            var result = this._sut.Handle(Enumerable.Empty<double>(), null, null);
+            var result = this._sut.Handle(Enumerable.Empty<double>(), null, null, null);
 
             ((IEnumerable<double>)result).ShouldBeEmpty();
         }
@@ -36,7 +36,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         {
             var items = new List<double> { 1000, 20.50 };
 
-            var result = this._sut.Handle(items, null, null);
+            var result = this._sut.Handle(items, null, null, null);
 
             ((IEnumerable<double>)result).ShouldContain(1000);
             ((IEnumerable<double>)result).ShouldContain(20.50);

--- a/src/JOS.ContentSerializer.Tests/ValueTypeListPropertyHandlers/IntListPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypeListPropertyHandlers/IntListPropertyHandlerTests.cs
@@ -18,7 +18,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         [Fact]
         public void GivenNullList_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, null);
 
             result.ShouldBeNull();
         }
@@ -26,7 +26,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         [Fact]
         public void GivenEmptyList_WhenHandle_ThenReturnsSameList()
         {
-            var result = this._sut.Handle(Enumerable.Empty<int>(), null, null);
+            var result = this._sut.Handle(Enumerable.Empty<int>(), null, null, null);
 
             ((IEnumerable<int>)result).ShouldBeEmpty();
         }
@@ -36,7 +36,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         {
             var items = new List<int> { 1000, 2000 };
 
-            var result = this._sut.Handle(items, null, null);
+            var result = this._sut.Handle(items, null, null, null);
 
             ((IEnumerable<int>)result).ShouldContain(1000);
             ((IEnumerable<int>)result).ShouldContain(2000);

--- a/src/JOS.ContentSerializer.Tests/ValueTypeListPropertyHandlers/StringListPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypeListPropertyHandlers/StringListPropertyHandlerTests.cs
@@ -18,7 +18,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         [Fact]
         public void GivenNullList_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, null);
 
             result.ShouldBeNull();
         }
@@ -26,7 +26,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         [Fact]
         public void GivenEmptyList_WhenHandle_ThenReturnsSameList()
         {
-            var result = this._sut.Handle(Enumerable.Empty<string>(), null, null);
+            var result = this._sut.Handle(Enumerable.Empty<string>(), null, null, null);
 
             ((IEnumerable<string>)result).ShouldBeEmpty();
         }
@@ -36,7 +36,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         {
             var items = new List<string>{"any", "value"};
 
-            var result = this._sut.Handle(items, null, null);
+            var result = this._sut.Handle(items, null, null, null);
 
             ((IEnumerable<string>)result).ShouldContain("any");
             ((IEnumerable<string>)result).ShouldContain("value");
@@ -48,7 +48,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypeListPropertyHandlers
         {
             var items = new[] { "any", "value" };
 
-            var result = this._sut.Handle(items, null, null);
+            var result = this._sut.Handle(items, null, null, null);
 
             ((IEnumerable<string>)result).ShouldContain("any");
             ((IEnumerable<string>)result).ShouldContain("value");

--- a/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/BoolPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/BoolPropertyHandlerTests.cs
@@ -24,7 +24,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
             var result = (bool)this._sut.Handle(
                 page.Bool,
                 page.GetType().GetProperty(nameof(ValueTypePropertyHandlerPage.Bool)),
-                page);
+                page, null);
 
             result.ShouldBeTrue();
         }

--- a/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/DateTimePropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/DateTimePropertyHandlerTests.cs
@@ -26,7 +26,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
             var result = (DateTime)this._sut.Handle(
                 page.DateTime,
                 page.GetType().GetProperty(nameof(ValueTypePropertyHandlerPage.DateTime)),
-                page);
+                page, null);
 
             result.ShouldBe(expected);
         }

--- a/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/DoublePropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/DoublePropertyHandlerTests.cs
@@ -24,7 +24,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
             var result = (double)this._sut.Handle(
                 page.Double,
                 page.GetType().GetProperty(nameof(ValueTypePropertyHandlerPage.Double)),
-                page);
+                page, null);
 
             result.ShouldBe(10.50);
         }

--- a/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/IntPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/IntPropertyHandlerTests.cs
@@ -25,7 +25,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
             var result = (int)this._sut.Handle(
                 page.Integer,
                 page.GetType().GetProperty(nameof(ValueTypePropertyHandlerPage.Integer)),
-                page);
+                page, null);
 
             result.ShouldBe(1000);
         }

--- a/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/StringPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/ValueTypePropertyHandlers/StringPropertyHandlerTests.cs
@@ -31,7 +31,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
 
             var result = this._sut.Handle(page.Heading,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.Heading)),
-                page);
+                page, null);
 
             ((string)result).ShouldBe(heading);
         }
@@ -46,7 +46,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
 
             var result = (List<SelectOption>)this._sut.Handle(page.SelectOne,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectOne)),
-                page);
+                page, null);
 
             result.ShouldContain(x => x.Selected && x.Value.Equals("option3") && x.Text.Equals("Option 3"));
             result.Count(x => x.Selected).ShouldBe(1);
@@ -64,7 +64,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
 
             var result = (IEnumerable<SelectOption>)this._sut.Handle(page.SelectOne,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectOne)),
-                page);
+                page, null);
 
             result.Count(x => x.Selected).ShouldBe(0);
         }
@@ -79,7 +79,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
 
             var result = (List<SelectOption>)this._sut.Handle(page.SelectMany,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectMany)),
-                page);
+                page, null);
 
             result.ShouldContain(x => x.Selected && x.Value.Equals("option3") && x.Text.Equals("Option 3"));
             result.ShouldContain(x => x.Selected && x.Value.Equals("option4") && x.Text.Equals("Option 4"));
@@ -99,7 +99,7 @@ namespace JOS.ContentSerializer.Tests.ValueTypePropertyHandlers
 
             var result = (IEnumerable<SelectOption>)this._sut.Handle(page.SelectMany,
                 page.GetType().GetProperty(nameof(StringPropertyHandlerPage.SelectOne)),
-                page);
+                page, null);
 
             result.Count(x => x.Selected).ShouldBe(0);
         }

--- a/src/JOS.ContentSerializer.Tests/XhtmlStringPropertyHandlerTests.cs
+++ b/src/JOS.ContentSerializer.Tests/XhtmlStringPropertyHandlerTests.cs
@@ -16,7 +16,7 @@ namespace JOS.ContentSerializer.Tests
         [Fact]
         public void GivenNullXhtmlString_WhenHandle_ThenReturnsNull()
         {
-            var result = this._sut.Handle(null, null, null);
+            var result = this._sut.Handle(null, null, null, null);
 
             result.ShouldBeNull();
         }

--- a/src/JOS.ContentSerializer/IPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/IPropertyHandler.cs
@@ -5,6 +5,7 @@ namespace JOS.ContentSerializer
 {
     public interface IPropertyHandler<in T>
     {
-        object Handle(T value, PropertyInfo property, IContentData contentData);
+        object Handle(T value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings);
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/BlockDataPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/BlockDataPropertyHandler.cs
@@ -15,7 +15,8 @@ namespace JOS.ContentSerializer.Internal.Default
             _contentSerializerSettings = contentSerializerSettings;
         }
 
-        public object Handle(BlockData value, PropertyInfo property, IContentData contentData)
+        public object Handle(BlockData value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return this._propertyManager.GetStructuredData(value, this._contentSerializerSettings);
         }

--- a/src/JOS.ContentSerializer/Internal/Default/BoolPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/BoolPropertyHandler.cs
@@ -5,7 +5,8 @@ namespace JOS.ContentSerializer.Internal.Default
 {
     public class BoolPropertyHandler : IPropertyHandler<bool>
     {
-        public object Handle(bool value, PropertyInfo property, IContentData contentData)
+        public object Handle(bool value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return value;
         }

--- a/src/JOS.ContentSerializer/Internal/Default/ContentAreaPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ContentAreaPropertyHandler.cs
@@ -12,33 +12,32 @@ namespace JOS.ContentSerializer.Internal.Default
     {
         private readonly IContentLoader _contentLoader;
         private readonly IPropertyManager _propertyManager;
-        private readonly IContentSerializerSettings _contentSerializerSettings;
 
         public ContentAreaPropertyHandler(
             IContentLoader contentLoader,
-            IPropertyManager propertyManager,
-            IContentSerializerSettings contentSerializerSettings)
+            IPropertyManager propertyManager)
+
         {
             _contentLoader = contentLoader ?? throw new ArgumentNullException(nameof(contentLoader));
             _propertyManager = propertyManager ?? throw new ArgumentNullException(nameof(propertyManager));
-            _contentSerializerSettings = contentSerializerSettings ?? throw new ArgumentNullException(nameof(contentSerializerSettings));
         }
 
-        public object Handle(ContentArea contentArea, PropertyInfo propertyInfo, IContentData contentData)
+        public object Handle(ContentArea contentArea, PropertyInfo propertyInfo, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             if (contentArea == null)
             {
                 return null;
             }
             var contentAreaItems = GetContentAreaItems(contentArea);
-            if (WrapItems(propertyInfo, this._contentSerializerSettings))
+            if (WrapItems(propertyInfo, contentSerializerSettings))
             {
                 var items = new Dictionary<string, List<object>>();
                 foreach (var item in contentAreaItems)
                 {
-                    var result = this._propertyManager.GetStructuredData(item, this._contentSerializerSettings);
+                    var result = this._propertyManager.GetStructuredData(item, contentSerializerSettings);
                     var typeName = item.GetOriginalType().Name;
-                    result.Add(this._contentSerializerSettings.BlockTypePropertyName, typeName);
+                    result.Add(contentSerializerSettings.BlockTypePropertyName, typeName);
                     if (items.ContainsKey(typeName))
                     {
                         items[typeName].Add(result);
@@ -56,8 +55,8 @@ namespace JOS.ContentSerializer.Internal.Default
                 var items = new List<object>();
                 foreach (var item in contentAreaItems)
                 {
-                    var result = this._propertyManager.GetStructuredData(item, this._contentSerializerSettings);
-                    result.Add(this._contentSerializerSettings.BlockTypePropertyName, item.GetOriginalType().Name);
+                    var result = this._propertyManager.GetStructuredData(item, contentSerializerSettings);
+                    result.Add(contentSerializerSettings.BlockTypePropertyName, item.GetOriginalType().Name);
                     items.Add(result);
                 }
 

--- a/src/JOS.ContentSerializer/Internal/Default/ContentAreaPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ContentAreaPropertyHandler.cs
@@ -31,7 +31,7 @@ namespace JOS.ContentSerializer.Internal.Default
                 return null;
             }
             var contentAreaItems = GetContentAreaItems(contentArea);
-            if (WrapItems(contentArea, this._contentSerializerSettings))
+            if (WrapItems(propertyInfo, this._contentSerializerSettings))
             {
                 var items = new Dictionary<string, List<object>>();
                 foreach (var item in contentAreaItems)
@@ -63,7 +63,7 @@ namespace JOS.ContentSerializer.Internal.Default
 
                 return items;
             }
-            
+
         }
 
         private IEnumerable<IContentData> GetContentAreaItems(ContentArea contentArea)
@@ -86,9 +86,9 @@ namespace JOS.ContentSerializer.Internal.Default
             return content;
         }
 
-        private static bool WrapItems(ContentArea contentArea, IContentSerializerSettings contentSerializerSettings)
+        private static bool WrapItems(PropertyInfo propertyInfo, IContentSerializerSettings contentSerializerSettings)
         {
-            var wrapItemsAttribute = contentArea.GetType().GetCustomAttribute<ContentSerializerWrapItemsAttribute>();
+            var wrapItemsAttribute = propertyInfo.GetCustomAttribute<ContentSerializerWrapItemsAttribute>();
             var wrapItems = wrapItemsAttribute?.WrapItems ?? contentSerializerSettings.WrapContentAreaItems;
             return wrapItems;
         }

--- a/src/JOS.ContentSerializer/Internal/Default/ContentReferenceListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ContentReferenceListPropertyHandler.cs
@@ -14,7 +14,8 @@ namespace JOS.ContentSerializer.Internal.Default
             _contentReferencePropertyHandler = contentReferencePropertyHandler ?? throw new ArgumentNullException(nameof(contentReferencePropertyHandler));
         }
 
-        public object Handle(IEnumerable<ContentReference> contentReferences, PropertyInfo property, IContentData contentData)
+        public object Handle(IEnumerable<ContentReference> contentReferences, PropertyInfo property,
+            IContentData contentData, IContentSerializerSettings contentSerializerSettings)
         {
             if (contentReferences == null)
             {
@@ -24,7 +25,7 @@ namespace JOS.ContentSerializer.Internal.Default
 
             foreach (var contentReference in contentReferences)
             {
-                var result = this._contentReferencePropertyHandler.Handle(contentReference, property, contentData);
+                var result = this._contentReferencePropertyHandler.Handle(contentReference, property, contentData, contentSerializerSettings);
                 links.Add(result);
             }
 

--- a/src/JOS.ContentSerializer/Internal/Default/ContentReferencePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ContentReferencePropertyHandler.cs
@@ -7,24 +7,23 @@ namespace JOS.ContentSerializer.Internal.Default
     public class ContentReferencePropertyHandler : IPropertyHandler<ContentReference>
     {
         private readonly IUrlHelper _urlHelper;
-        private readonly IContentSerializerSettings _contentSerializerSettings;
 
-        public ContentReferencePropertyHandler(IUrlHelper urlHelper, IContentSerializerSettings contentSerializerSettings)
+        public ContentReferencePropertyHandler(IUrlHelper urlHelper)
         {
             _urlHelper = urlHelper;
-            _contentSerializerSettings = contentSerializerSettings ?? throw new ArgumentNullException(nameof(contentSerializerSettings));
         }
 
-        public object Handle(ContentReference contentReference, PropertyInfo propertyInfo, IContentData contentData)
+        public object Handle(ContentReference contentReference, PropertyInfo propertyInfo, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             if (contentReference == null || contentReference == ContentReference.EmptyReference)
             {
                 return null;
             }
 
-            var url = new Uri(this._urlHelper.ContentUrl(contentReference, this._contentSerializerSettings.UrlSettings));
+            var url = new Uri(this._urlHelper.ContentUrl(contentReference, contentSerializerSettings.UrlSettings));
 
-            if (this._contentSerializerSettings.UrlSettings.UseAbsoluteUrls && url.IsAbsoluteUri)
+            if (contentSerializerSettings.UrlSettings.UseAbsoluteUrls && url.IsAbsoluteUri)
             {
                 return url.AbsoluteUri;
             }

--- a/src/JOS.ContentSerializer/Internal/Default/LinkItemCollectionPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/LinkItemCollectionPropertyHandler.cs
@@ -11,15 +11,14 @@ namespace JOS.ContentSerializer.Internal.Default
     public class LinkItemCollectionPropertyHandler : IPropertyHandler<LinkItemCollection>
     {
         private readonly IUrlHelper _urlHelper;
-        private readonly IContentSerializerSettings _contentSerializerSettings;
 
-        public LinkItemCollectionPropertyHandler(IUrlHelper urlHelper, IContentSerializerSettings contentSerializerSettings)
+        public LinkItemCollectionPropertyHandler(IUrlHelper urlHelper)
         {
             _urlHelper = urlHelper ?? throw new ArgumentNullException(nameof(urlHelper));
-            _contentSerializerSettings = contentSerializerSettings ?? throw new ArgumentNullException(nameof(contentSerializerSettings));
         }
 
-        public object Handle(LinkItemCollection linkItemCollection, PropertyInfo propertyInfo, IContentData contentData)
+        public object Handle(LinkItemCollection linkItemCollection, PropertyInfo propertyInfo, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             if (linkItemCollection == null)
             {
@@ -33,7 +32,7 @@ namespace JOS.ContentSerializer.Internal.Default
                 if (link.ReferencedPermanentLinkIds.Any())
                 {
                     var url = new Url(link.Href);
-                    prettyUrl = this._urlHelper.ContentUrl(url, this._contentSerializerSettings.UrlSettings);
+                    prettyUrl = this._urlHelper.ContentUrl(url, contentSerializerSettings.UrlSettings);
                 }
                 links.Add(new LinkItem
                 {

--- a/src/JOS.ContentSerializer/Internal/Default/PageReferencePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/PageReferencePropertyHandler.cs
@@ -13,9 +13,10 @@ namespace JOS.ContentSerializer.Internal.Default
             _contentReferencePropertyHandler = contentReferencePropertyHandler ?? throw new ArgumentNullException(nameof(contentReferencePropertyHandler));
         }
 
-        public object Handle(PageReference value, PropertyInfo property, IContentData contentData)
+        public object Handle(PageReference value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
-            return this._contentReferencePropertyHandler.Handle(value, property, contentData);
+            return this._contentReferencePropertyHandler.Handle(value, property, contentData, contentSerializerSettings);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/PageTypePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/PageTypePropertyHandler.cs
@@ -6,7 +6,8 @@ namespace JOS.ContentSerializer.Internal.Default
 {
     public class PageTypePropertyHandler : IPropertyHandler<PageType>
     {
-        public object Handle(PageType value, PropertyInfo propertyInfo, IContentData contentData)
+        public object Handle(PageType value, PropertyInfo propertyInfo, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return value == null ? null : new PageTypeModel(value.Name, value.ID);
         }

--- a/src/JOS.ContentSerializer/Internal/Default/StringPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/StringPropertyHandler.cs
@@ -16,7 +16,8 @@ namespace JOS.ContentSerializer.Internal.Default
             _selectManyStrategy = selectManyStrategy ?? throw new ArgumentNullException(nameof(selectManyStrategy));
         }
 
-        public object Handle(string stringValue, PropertyInfo property, IContentData contentData)
+        public object Handle(string stringValue, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             if (HasSelectAttribute(property))
             {

--- a/src/JOS.ContentSerializer/Internal/Default/UrlPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/UrlPropertyHandler.cs
@@ -8,16 +8,15 @@ namespace JOS.ContentSerializer.Internal.Default
     public class UrlPropertyHandler : IPropertyHandler<Url>
     {
         private readonly IUrlHelper _urlHelper;
-        private readonly IContentSerializerSettings _contentSerializerSettings;
         private const string MailTo = "mailto";
 
-        public UrlPropertyHandler(IUrlHelper urlHelper, IContentSerializerSettings contentSerializerSettings)
+        public UrlPropertyHandler(IUrlHelper urlHelper)
         {
             _urlHelper = urlHelper ?? throw new ArgumentNullException(nameof(urlHelper));
-            _contentSerializerSettings = contentSerializerSettings ?? throw new ArgumentNullException(nameof(contentSerializerSettings));
         }
 
-        public object Handle(Url url, PropertyInfo propertyInfo, IContentData contentData)
+        public object Handle(Url url, PropertyInfo propertyInfo, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             if (url == null)
             {
@@ -28,7 +27,7 @@ namespace JOS.ContentSerializer.Internal.Default
 
             if (url.IsAbsoluteUri)
             {
-                if (this._contentSerializerSettings.UrlSettings.UseAbsoluteUrls)
+                if (contentSerializerSettings.UrlSettings.UseAbsoluteUrls)
                 {
                     return url.OriginalString;
                 }
@@ -36,7 +35,7 @@ namespace JOS.ContentSerializer.Internal.Default
                 return url.PathAndQuery;
             }
 
-            return this._urlHelper.ContentUrl(url, this._contentSerializerSettings.UrlSettings);
+            return this._urlHelper.ContentUrl(url, contentSerializerSettings.UrlSettings);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/DateTimeListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/DateTimeListPropertyHandler.cs
@@ -7,7 +7,8 @@ namespace JOS.ContentSerializer.Internal.Default.ValueListPropertyHandlers
 {
     public class DateTimeListPropertyHandler : IPropertyHandler<IEnumerable<DateTime>>
     {
-        public object Handle(IEnumerable<DateTime> value, PropertyInfo property, IContentData contentData)
+        public object Handle(IEnumerable<DateTime> value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return value;
         }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/DoubleListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/DoubleListPropertyHandler.cs
@@ -6,7 +6,8 @@ namespace JOS.ContentSerializer.Internal.Default.ValueListPropertyHandlers
 {
     public class DoubleListPropertyHandler : IPropertyHandler<IEnumerable<double>>
     {
-        public object Handle(IEnumerable<double> value, PropertyInfo property, IContentData contentData)
+        public object Handle(IEnumerable<double> value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return value;
         }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/IntListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/IntListPropertyHandler.cs
@@ -6,7 +6,8 @@ namespace JOS.ContentSerializer.Internal.Default.ValueListPropertyHandlers
 {
     public class IntListPropertyHandler : IPropertyHandler<IEnumerable<int>>
     {
-        public object Handle(IEnumerable<int> value, PropertyInfo property, IContentData contentData)
+        public object Handle(IEnumerable<int> value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return value;
         }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/StringListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/StringListPropertyHandler.cs
@@ -6,7 +6,8 @@ namespace JOS.ContentSerializer.Internal.Default.ValueListPropertyHandlers
 {
     public class StringListPropertyHandler : IPropertyHandler<IEnumerable<string>>
     {
-        public object Handle(IEnumerable<string> value, PropertyInfo property, IContentData contentData)
+        public object Handle(IEnumerable<string> value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return value;
         }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/DateTimePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/DateTimePropertyHandler.cs
@@ -6,7 +6,8 @@ namespace JOS.ContentSerializer.Internal.Default.ValueTypePropertyHandlers
 {
     public class DateTimePropertyHandler : IPropertyHandler<DateTime>
     {
-        public object Handle(DateTime value, PropertyInfo property, IContentData contentData)
+        public object Handle(DateTime value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return value;
         }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/DoublePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/DoublePropertyHandler.cs
@@ -5,7 +5,8 @@ namespace JOS.ContentSerializer.Internal.Default.ValueTypePropertyHandlers
 {
     public class DoublePropertyHandler : IPropertyHandler<double>
     {
-        public object Handle(double value, PropertyInfo property, IContentData contentData)
+        public object Handle(double value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return value;
         }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/IntPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/IntPropertyHandler.cs
@@ -5,7 +5,8 @@ namespace JOS.ContentSerializer.Internal.Default.ValueTypePropertyHandlers
 {
     public class IntPropertyHandler : IPropertyHandler<int>
     {
-        public object Handle(int value, PropertyInfo property, IContentData contentData)
+        public object Handle(int value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             return value;
         }

--- a/src/JOS.ContentSerializer/Internal/Default/XhtmlStringPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/XhtmlStringPropertyHandler.cs
@@ -5,7 +5,8 @@ namespace JOS.ContentSerializer.Internal.Default
 {
     public class XhtmlStringPropertyHandler : IPropertyHandler<XhtmlString>
     {
-        public object Handle(XhtmlString value, PropertyInfo property, IContentData contentData)
+        public object Handle(XhtmlString value, PropertyInfo property, IContentData contentData,
+            IContentSerializerSettings contentSerializerSettings)
         {
             //TODO Fix parsing of images/blocks/links etc so we can provide pretty links.
             return value?.ToHtmlString();

--- a/src/JOS.ContentSerializer/Internal/PropertyManager.cs
+++ b/src/JOS.ContentSerializer/Internal/PropertyManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using EPiServer.Core;
+using EPiServer.ServiceLocation;
 
 namespace JOS.ContentSerializer.Internal
 {
@@ -43,7 +44,8 @@ namespace JOS.ContentSerializer.Internal
                 {
                     var key = this._propertyNameStrategy.GetPropertyName(property);
                     var value = property.GetValue(contentData);
-                    var result = method.Invoke(propertyHandler, new[] { value, property, contentData });
+                    ServiceLocator.Current.TryGetExistingInstance(typeof(IContentSerializerSettings), out var contentSerializerSettings);
+                    var result = method.Invoke(propertyHandler, new[] { value, property, contentData,  settings ?? contentSerializerSettings});
                     structuredData.Add(key, result);
                 }
             }


### PR DESCRIPTION
Two things had to be fixed:

- reading passed configuration

- reading ContentArea attribute

I have only doubts reg 1st point. Imho this configuration should be global, so we should register it as other modules/handlers so it should be static. If we want to override it in particular places we should use property attributes. But If you would like to keep your concept I think my solution should be enough. 

Note. `UrlPropertyHandler` has to be fixed because in some cases it doesn't do what it supposed to. Now it's checking if a url is absolute, I think it should checks if the link is external instead. For internal it should call:
`this._urlHelper.ContentUrl(url, contentSerializerSettings.UrlSettings);`
 Please check two failing tests. 