### PR TITLE
Use global configuration

### DIFF
--- a/src/JOS.ContentSerializer/Internal/JsonContentSerializer.cs
+++ b/src/JOS.ContentSerializer/Internal/JsonContentSerializer.cs
@@ -8,15 +8,17 @@ namespace JOS.ContentSerializer.Internal
     public class JsonContentSerializer : IContentJsonSerializer
     {
         private readonly IPropertyManager _propertyManager;
+        private readonly IContentSerializerSettings _contentSerializerSettings;
 
-        public JsonContentSerializer(IPropertyManager propertyManager)
+        public JsonContentSerializer(IPropertyManager propertyManager, IContentSerializerSettings contentSerializerSettings)
         {
             _propertyManager = propertyManager ?? throw new ArgumentNullException(nameof(propertyManager));
+            _contentSerializerSettings = contentSerializerSettings ?? throw new ArgumentNullException(nameof(contentSerializerSettings));
         }
 
         public string Serialize(IContentData contentData)
         {
-            return Execute(contentData, new ContentSerializerSettings());
+            return Execute(contentData, _contentSerializerSettings);
         }
 
         public string Serialize(IContentData contentData, IContentSerializerSettings settings)
@@ -26,7 +28,7 @@ namespace JOS.ContentSerializer.Internal
 
         public object GetStructuredData(IContentData contentData)
         {
-            return this._propertyManager.GetStructuredData(contentData, new ContentSerializerSettings());
+            return this._propertyManager.GetStructuredData(contentData, _contentSerializerSettings);
         }
 
         public object GetStructuredData(IContentData contentData, IContentSerializerSettings settings)


### PR DESCRIPTION
I think global, registered configuration should be used instead of creating a new instance. It allows us to register our own config.