### PR TITLE
Property handlers may now use settings passed as argument instead of injected ones.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Now, if you call .ToJson on a StartPage instance you would only get the Heading 
 }
 ```
 
-To add support for it, first create a new class that implements the ```IPropertyHandler<>``` interface
+To add support for it, first create a new class that implements the ```IPropertyHandler2<>``` interface
 
 ```csharp
-public class KeyValueItemListPropertyHandler : IPropertyHandler<IEnumerable<KeyValueItem>>
+public class KeyValueItemListPropertyHandler : IPropertyHandler2<IEnumerable<KeyValueItem>>
 {
-    public object Handle(IEnumerable<KeyValueItem> value, PropertyInfo property, IContentData contentData)
+    public object Handle2(IEnumerable<KeyValueItem> value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
     {
         // Do whatever you want with the property here.
         return value;
@@ -73,7 +73,7 @@ public class MyConfigurationModule : IConfigurableModule
 {
     public void ConfigureContainer(ServiceConfigurationContext context)
     { 
-    context.Services.AddSingleton<IPropertyHandler<IEnumerable<KeyValueItem>>, KeyValueItemListPropertyHandler>();
+    context.Services.AddSingleton<IPropertyHandler2<IEnumerable<KeyValueItem>>, KeyValueItemListPropertyHandler>();
     }
 }
 ```
@@ -100,9 +100,9 @@ Say that you, for some reason, want all strings to return "JOSEF OTTOSSON!!" ins
 
 Just create a new propertyhandler for strings like this.
 ```csharp
-public class JosefStringPropertyHandler : IPropertyHandler<string>
+public class JosefStringPropertyHandler : IPropertyHandler2<string>
 {
-    public object Handle(string value, PropertyInfo property, IContentData contentData)
+    public object Handle2(string value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
     {
         return "JOSEF OTTOSSON!!";
     }
@@ -111,7 +111,7 @@ public class JosefStringPropertyHandler : IPropertyHandler<string>
 
 Then swap out the default ```StringPropertyHandler``` in the DI container like this:
 ```csharp
-context.Services.AddSingleton<IPropertyHandler<string>, JosefStringPropertyHandler>();
+context.Services.AddSingleton<IPropertyHandler2<string>, JosefStringPropertyHandler>();
 ```
 **Don't forget to unregister the default ``IPropertyHandler<string>`` as well**
 

--- a/src/JOS.ContentSerializer/IPropertyHandler2.cs
+++ b/src/JOS.ContentSerializer/IPropertyHandler2.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+using EPiServer.Core;
+
+namespace JOS.ContentSerializer
+{
+    /// <summary>
+    /// Interface for creating property handlers with a handle method (Handle2) accepting the IContentSerializerSettings object
+    /// as a parameter. Please use this interface instead of the IPropertyHandler one.
+    /// For naming conventions, please see https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/general-naming-conventions
+    /// </summary>
+    /// <typeparam name="T">Type to be handled by this property handler.</typeparam>
+    public interface IPropertyHandler2<in T>
+    {
+        object Handle2(T value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings);
+    }
+}

--- a/src/JOS.ContentSerializer/Internal/Default/BlockDataPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/BlockDataPropertyHandler.cs
@@ -4,7 +4,7 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class BlockDataPropertyHandler : IPropertyHandler<BlockData>
+    public class BlockDataPropertyHandler : IPropertyHandler<BlockData>, IPropertyHandler2<BlockData>
     {
         private readonly IPropertyManager _propertyManager;
         private readonly IContentSerializerSettings _contentSerializerSettings;
@@ -18,6 +18,11 @@ namespace JOS.ContentSerializer.Internal.Default
         public object Handle(BlockData value, PropertyInfo property, IContentData contentData)
         {
             return this._propertyManager.GetStructuredData(value, this._contentSerializerSettings);
+        }
+
+        public object Handle2(BlockData value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return this._propertyManager.GetStructuredData(value, contentSerializerSettings);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/BoolPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/BoolPropertyHandler.cs
@@ -3,11 +3,16 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class BoolPropertyHandler : IPropertyHandler<bool>
+    public class BoolPropertyHandler : IPropertyHandler<bool>, IPropertyHandler2<bool>
     {
         public object Handle(bool value, PropertyInfo property, IContentData contentData)
         {
             return value;
+        }
+
+        public object Handle2(bool value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/ContentAreaPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ContentAreaPropertyHandler.cs
@@ -8,7 +8,7 @@ using JOS.ContentSerializer.Attributes;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class ContentAreaPropertyHandler : IPropertyHandler<ContentArea>
+    public class ContentAreaPropertyHandler : IPropertyHandler<ContentArea>, IPropertyHandler2<ContentArea>
     {
         private readonly IContentLoader _contentLoader;
         private readonly IPropertyManager _propertyManager;
@@ -26,19 +26,29 @@ namespace JOS.ContentSerializer.Internal.Default
 
         public object Handle(ContentArea contentArea, PropertyInfo propertyInfo, IContentData contentData)
         {
+            return HandleInternal(contentArea, this._contentSerializerSettings);
+        }
+
+        public object Handle2(ContentArea contentArea, PropertyInfo propertyInfo, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return HandleInternal(contentArea, contentSerializerSettings);
+        }
+
+        private object HandleInternal(ContentArea contentArea, IContentSerializerSettings contentSerializerSettings)
+        {
             if (contentArea == null)
             {
                 return null;
             }
             var contentAreaItems = GetContentAreaItems(contentArea);
-            if (WrapItems(contentArea, this._contentSerializerSettings))
+            if (WrapItems(contentArea, contentSerializerSettings))
             {
                 var items = new Dictionary<string, List<object>>();
                 foreach (var item in contentAreaItems)
                 {
-                    var result = this._propertyManager.GetStructuredData(item, this._contentSerializerSettings);
+                    var result = this._propertyManager.GetStructuredData(item, contentSerializerSettings);
                     var typeName = item.GetOriginalType().Name;
-                    result.Add(this._contentSerializerSettings.BlockTypePropertyName, typeName);
+                    result.Add(contentSerializerSettings.BlockTypePropertyName, typeName);
                     if (items.ContainsKey(typeName))
                     {
                         items[typeName].Add(result);
@@ -56,14 +66,13 @@ namespace JOS.ContentSerializer.Internal.Default
                 var items = new List<object>();
                 foreach (var item in contentAreaItems)
                 {
-                    var result = this._propertyManager.GetStructuredData(item, this._contentSerializerSettings);
-                    result.Add(this._contentSerializerSettings.BlockTypePropertyName, item.GetOriginalType().Name);
+                    var result = this._propertyManager.GetStructuredData(item, contentSerializerSettings);
+                    result.Add(contentSerializerSettings.BlockTypePropertyName, item.GetOriginalType().Name);
                     items.Add(result);
                 }
 
                 return items;
             }
-            
         }
 
         private IEnumerable<IContentData> GetContentAreaItems(ContentArea contentArea)

--- a/src/JOS.ContentSerializer/Internal/Default/ContentReferenceListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ContentReferenceListPropertyHandler.cs
@@ -5,7 +5,7 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class ContentReferenceListPropertyHandler : IPropertyHandler<IEnumerable<ContentReference>>
+    public class ContentReferenceListPropertyHandler : IPropertyHandler<IEnumerable<ContentReference>>, IPropertyHandler2<IEnumerable<ContentReference>>
     {
         private readonly IPropertyHandler<ContentReference> _contentReferencePropertyHandler;
 
@@ -16,6 +16,18 @@ namespace JOS.ContentSerializer.Internal.Default
 
         public object Handle(IEnumerable<ContentReference> contentReferences, PropertyInfo property, IContentData contentData)
         {
+            return HandleInternal(contentReferences, (contentReference) => this._contentReferencePropertyHandler.Handle(contentReference, property, contentData));
+        }
+
+        public object Handle2(IEnumerable<ContentReference> contentReferences, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            // Internal JOS IPropertyHandler implementations always implement IPropertyHandler2 as well.
+            return HandleInternal(contentReferences, (contentReference) =>
+                ((IPropertyHandler2<ContentReference>)this._contentReferencePropertyHandler).Handle2(contentReference, property, contentData, contentSerializerSettings));
+        }
+
+        private object HandleInternal(IEnumerable<ContentReference> contentReferences, Func<ContentReference, object> handle)
+        {
             if (contentReferences == null)
             {
                 return null;
@@ -24,7 +36,7 @@ namespace JOS.ContentSerializer.Internal.Default
 
             foreach (var contentReference in contentReferences)
             {
-                var result = this._contentReferencePropertyHandler.Handle(contentReference, property, contentData);
+                var result = handle(contentReference);
                 links.Add(result);
             }
 

--- a/src/JOS.ContentSerializer/Internal/Default/ContentReferencePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ContentReferencePropertyHandler.cs
@@ -4,7 +4,7 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class ContentReferencePropertyHandler : IPropertyHandler<ContentReference>
+    public class ContentReferencePropertyHandler : IPropertyHandler<ContentReference>, IPropertyHandler2<ContentReference>
     {
         private readonly IUrlHelper _urlHelper;
         private readonly IContentSerializerSettings _contentSerializerSettings;
@@ -17,14 +17,24 @@ namespace JOS.ContentSerializer.Internal.Default
 
         public object Handle(ContentReference contentReference, PropertyInfo propertyInfo, IContentData contentData)
         {
+            return HandleInternal(contentReference, this._contentSerializerSettings);
+        }
+
+        public object Handle2(ContentReference contentReference, PropertyInfo propertyInfo, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return HandleInternal(contentReference, contentSerializerSettings);
+        }
+
+        private object HandleInternal(ContentReference contentReference, IContentSerializerSettings contentSerializerSettings)
+        {
             if (contentReference == null || contentReference == ContentReference.EmptyReference)
             {
                 return null;
             }
 
-            var url = new Uri(this._urlHelper.ContentUrl(contentReference, this._contentSerializerSettings.UrlSettings));
+            var url = new Uri(this._urlHelper.ContentUrl(contentReference, contentSerializerSettings.UrlSettings));
 
-            if (this._contentSerializerSettings.UrlSettings.UseAbsoluteUrls && url.IsAbsoluteUri)
+            if (contentSerializerSettings.UrlSettings.UseAbsoluteUrls && url.IsAbsoluteUri)
             {
                 return url.AbsoluteUri;
             }

--- a/src/JOS.ContentSerializer/Internal/Default/LinkItemCollectionPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/LinkItemCollectionPropertyHandler.cs
@@ -8,7 +8,7 @@ using EPiServer.SpecializedProperties;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class LinkItemCollectionPropertyHandler : IPropertyHandler<LinkItemCollection>
+    public class LinkItemCollectionPropertyHandler : IPropertyHandler<LinkItemCollection>, IPropertyHandler2<LinkItemCollection>
     {
         private readonly IUrlHelper _urlHelper;
         private readonly IContentSerializerSettings _contentSerializerSettings;
@@ -20,6 +20,16 @@ namespace JOS.ContentSerializer.Internal.Default
         }
 
         public object Handle(LinkItemCollection linkItemCollection, PropertyInfo propertyInfo, IContentData contentData)
+        {
+            return HandleInternal(linkItemCollection, this._contentSerializerSettings);
+        }
+
+        public object Handle2(LinkItemCollection linkItemCollection, PropertyInfo propertyInfo, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return HandleInternal(linkItemCollection, contentSerializerSettings);
+        }
+
+        private object HandleInternal(LinkItemCollection linkItemCollection, IContentSerializerSettings contentSerializerSettings)
         {
             if (linkItemCollection == null)
             {
@@ -33,7 +43,7 @@ namespace JOS.ContentSerializer.Internal.Default
                 if (link.ReferencedPermanentLinkIds.Any())
                 {
                     var url = new Url(link.Href);
-                    prettyUrl = this._urlHelper.ContentUrl(url, this._contentSerializerSettings.UrlSettings);
+                    prettyUrl = this._urlHelper.ContentUrl(url, contentSerializerSettings.UrlSettings);
                 }
                 links.Add(new LinkItem
                 {

--- a/src/JOS.ContentSerializer/Internal/Default/NullableTimeSpanPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/NullableTimeSpanPropertyHandler.cs
@@ -4,11 +4,16 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class NullableTimeSpanPropertyHandler : IPropertyHandler<TimeSpan?>
+    public class NullableTimeSpanPropertyHandler : IPropertyHandler<TimeSpan?>, IPropertyHandler2<TimeSpan?>
     {
         public object Handle(TimeSpan? value, PropertyInfo property, IContentData contentData)
         {
             return value?.ToString();
+        }
+
+        public object Handle2(TimeSpan? value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/PageReferencePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/PageReferencePropertyHandler.cs
@@ -4,7 +4,7 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class PageReferencePropertyHandler : IPropertyHandler<PageReference>
+    public class PageReferencePropertyHandler : IPropertyHandler<PageReference>, IPropertyHandler2<PageReference>
     {
         private readonly IPropertyHandler<ContentReference> _contentReferencePropertyHandler;
 
@@ -16,6 +16,12 @@ namespace JOS.ContentSerializer.Internal.Default
         public object Handle(PageReference value, PropertyInfo property, IContentData contentData)
         {
             return this._contentReferencePropertyHandler.Handle(value, property, contentData);
+        }
+
+        public object Handle2(PageReference value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            // Internal JOS IPropertyHandler implementations always implement IPropertyHandler2 as well.
+            return ((IPropertyHandler2<ContentReference>)this._contentReferencePropertyHandler).Handle2(value, property, contentData, contentSerializerSettings);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/PageTypePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/PageTypePropertyHandler.cs
@@ -4,11 +4,16 @@ using EPiServer.DataAbstraction;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class PageTypePropertyHandler : IPropertyHandler<PageType>
+    public class PageTypePropertyHandler : IPropertyHandler<PageType>, IPropertyHandler2<PageType>
     {
         public object Handle(PageType value, PropertyInfo propertyInfo, IContentData contentData)
         {
             return value == null ? null : new PageTypeModel(value.Name, value.ID);
+        }
+
+        public object Handle2(PageType value, PropertyInfo propertyInfo, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, propertyInfo, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/StringPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/StringPropertyHandler.cs
@@ -5,7 +5,7 @@ using EPiServer.Shell.ObjectEditing;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class StringPropertyHandler : IPropertyHandler<string>
+    public class StringPropertyHandler : IPropertyHandler<string>, IPropertyHandler2<string>
     {
         private readonly ISelectOneStrategy _selectOneStrategy;
         private readonly ISelectManyStrategy _selectManyStrategy;
@@ -35,6 +35,11 @@ namespace JOS.ContentSerializer.Internal.Default
             }
 
             return stringValue;
+        }
+
+        public object Handle2(string stringValue, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(stringValue, property, contentData);
         }
 
         private static ISelectionFactory CreateSelectionFactoryInstance(Type type)

--- a/src/JOS.ContentSerializer/Internal/Default/UrlPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/UrlPropertyHandler.cs
@@ -5,7 +5,7 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class UrlPropertyHandler : IPropertyHandler<Url>
+    public class UrlPropertyHandler : IPropertyHandler<Url>, IPropertyHandler2<Url>
     {
         private readonly IUrlHelper _urlHelper;
         private readonly IContentSerializerSettings _contentSerializerSettings;
@@ -19,6 +19,16 @@ namespace JOS.ContentSerializer.Internal.Default
 
         public object Handle(Url url, PropertyInfo propertyInfo, IContentData contentData)
         {
+            return HandleInternal(url, this._contentSerializerSettings);
+        }
+
+        public object Handle2(Url url, PropertyInfo propertyInfo, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return HandleInternal(url, contentSerializerSettings);
+        }
+
+        private object HandleInternal(Url url, IContentSerializerSettings contentSerializerSettings)
+        {
             if (url == null)
             {
                 return null;
@@ -28,7 +38,7 @@ namespace JOS.ContentSerializer.Internal.Default
 
             if (url.IsAbsoluteUri)
             {
-                if (this._contentSerializerSettings.UrlSettings.UseAbsoluteUrls)
+                if (contentSerializerSettings.UrlSettings.UseAbsoluteUrls)
                 {
                     return url.OriginalString;
                 }
@@ -36,7 +46,7 @@ namespace JOS.ContentSerializer.Internal.Default
                 return url.PathAndQuery;
             }
 
-            return this._urlHelper.ContentUrl(url, this._contentSerializerSettings.UrlSettings);
+            return this._urlHelper.ContentUrl(url, contentSerializerSettings.UrlSettings);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/DateTimeListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/DateTimeListPropertyHandler.cs
@@ -5,11 +5,16 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default.ValueListPropertyHandlers
 {
-    public class DateTimeListPropertyHandler : IPropertyHandler<IEnumerable<DateTime>>
+    public class DateTimeListPropertyHandler : IPropertyHandler<IEnumerable<DateTime>>, IPropertyHandler2<IEnumerable<DateTime>>
     {
         public object Handle(IEnumerable<DateTime> value, PropertyInfo property, IContentData contentData)
         {
             return value;
+        }
+
+        public object Handle2(IEnumerable<DateTime> value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/DoubleListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/DoubleListPropertyHandler.cs
@@ -4,11 +4,16 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default.ValueListPropertyHandlers
 {
-    public class DoubleListPropertyHandler : IPropertyHandler<IEnumerable<double>>
+    public class DoubleListPropertyHandler : IPropertyHandler<IEnumerable<double>>, IPropertyHandler2<IEnumerable<double>>
     {
         public object Handle(IEnumerable<double> value, PropertyInfo property, IContentData contentData)
         {
             return value;
+        }
+
+        public object Handle2(IEnumerable<double> value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/IntListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/IntListPropertyHandler.cs
@@ -4,11 +4,16 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default.ValueListPropertyHandlers
 {
-    public class IntListPropertyHandler : IPropertyHandler<IEnumerable<int>>
+    public class IntListPropertyHandler : IPropertyHandler<IEnumerable<int>>, IPropertyHandler2<IEnumerable<int>>
     {
         public object Handle(IEnumerable<int> value, PropertyInfo property, IContentData contentData)
         {
             return value;
+        }
+
+        public object Handle2(IEnumerable<int> value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/StringListPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueListPropertyHandlers/StringListPropertyHandler.cs
@@ -4,11 +4,16 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default.ValueListPropertyHandlers
 {
-    public class StringListPropertyHandler : IPropertyHandler<IEnumerable<string>>
+    public class StringListPropertyHandler : IPropertyHandler<IEnumerable<string>>, IPropertyHandler2<IEnumerable<string>>
     {
         public object Handle(IEnumerable<string> value, PropertyInfo property, IContentData contentData)
         {
             return value;
+        }
+
+        public object Handle2(IEnumerable<string> value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/DateTimePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/DateTimePropertyHandler.cs
@@ -4,11 +4,16 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default.ValueTypePropertyHandlers
 {
-    public class DateTimePropertyHandler : IPropertyHandler<DateTime>
+    public class DateTimePropertyHandler : IPropertyHandler<DateTime>, IPropertyHandler2<DateTime>
     {
         public object Handle(DateTime value, PropertyInfo property, IContentData contentData)
         {
             return value;
+        }
+
+        public object Handle2(DateTime value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/DoublePropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/DoublePropertyHandler.cs
@@ -3,11 +3,16 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default.ValueTypePropertyHandlers
 {
-    public class DoublePropertyHandler : IPropertyHandler<double>
+    public class DoublePropertyHandler : IPropertyHandler<double>, IPropertyHandler2<double>
     {
         public object Handle(double value, PropertyInfo property, IContentData contentData)
         {
             return value;
+        }
+
+        public object Handle2(double value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/IntPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/ValueTypePropertyHandlers/IntPropertyHandler.cs
@@ -3,11 +3,16 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default.ValueTypePropertyHandlers
 {
-    public class IntPropertyHandler : IPropertyHandler<int>
+    public class IntPropertyHandler : IPropertyHandler<int>, IPropertyHandler2<int>
     {
         public object Handle(int value, PropertyInfo property, IContentData contentData)
         {
             return value;
+        }
+
+        public object Handle2(int value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/Default/XhtmlStringPropertyHandler.cs
+++ b/src/JOS.ContentSerializer/Internal/Default/XhtmlStringPropertyHandler.cs
@@ -3,12 +3,17 @@ using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal.Default
 {
-    public class XhtmlStringPropertyHandler : IPropertyHandler<XhtmlString>
+    public class XhtmlStringPropertyHandler : IPropertyHandler<XhtmlString>, IPropertyHandler2<XhtmlString>
     {
         public object Handle(XhtmlString value, PropertyInfo property, IContentData contentData)
         {
             //TODO Fix parsing of images/blocks/links etc so we can provide pretty links.
             return value?.ToHtmlString();
+        }
+
+        public object Handle2(XhtmlString value, PropertyInfo property, IContentData contentData, IContentSerializerSettings contentSerializerSettings)
+        {
+            return Handle(value, property, contentData);
         }
     }
 }

--- a/src/JOS.ContentSerializer/Internal/PropertyManager.cs
+++ b/src/JOS.ContentSerializer/Internal/PropertyManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using EPiServer.Core;
 
 namespace JOS.ContentSerializer.Internal
@@ -38,7 +39,18 @@ namespace JOS.ContentSerializer.Internal
                     continue;
                 }
 
-                var method = propertyHandler.GetType().GetMethod(nameof(IPropertyHandler<object>.Handle));
+                var methods = propertyHandler.GetType().GetMethods();
+                var method = methods.SingleOrDefault(m => m.Name == nameof(IPropertyHandler2<object>.Handle2));
+                if (method != null)
+                {
+                    var key = this._propertyNameStrategy.GetPropertyName(property);
+                    var value = property.GetValue(contentData);
+                    var result = method.Invoke(propertyHandler, new[] { value, property, contentData, settings });
+                    structuredData.Add(key, result);
+                    continue;
+                }
+
+                method = methods.SingleOrDefault(m => m.Name == nameof(IPropertyHandler<object>.Handle));
                 if (method != null)
                 {
                     var key = this._propertyNameStrategy.GetPropertyName(property);

--- a/src/JOS.ContentSerializer/Internal/UrlHelperAdapter.cs
+++ b/src/JOS.ContentSerializer/Internal/UrlHelperAdapter.cs
@@ -9,6 +9,10 @@ namespace JOS.ContentSerializer.Internal
 {
     public class UrlHelperAdapter : IUrlHelper
     {
+        // TODO: Use a parameter in the methods for the IContentSerializerSettings implementation instead of
+        // injecting it via dependency injection. The injected one will be the wrong one if someone wants to
+        // occationally use their own IContentSerializerSettings implementation.
+
         private readonly UrlHelper _urlHelper;
         private readonly ISiteDefinitionResolver _siteDefinitionResolver;
         private readonly IRequestHostResolver _requestHostResolver;

--- a/src/JOS.ContentSerializer/JOS.ContentSerializer.csproj
+++ b/src/JOS.ContentSerializer/JOS.ContentSerializer.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Internal\LinkItem.cs" />
     <Compile Include="Internal\Default\StringPropertyHandler.cs" />
     <Compile Include="Internal\UrlHelperAdapter.cs" />
+    <Compile Include="IPropertyHandler2.cs" />
     <Compile Include="IPropertyHandlerService.cs" />
     <Compile Include="ISelectManyStrategy.cs" />
     <Compile Include="ISelectOneStrategy.cs" />


### PR DESCRIPTION
Added possibility to pass a custom implementation of the IContentSerializerSettings interface through to property handlers. The one retrieved via dependency injection will not be the custom implementation.

Did changes through a separate interface IPropertyHandler2 with a new method Handle2 that accepts the settings as a parameter (Microsoft [General Naming Conventions](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/general-naming-conventions)). This is in order to maintain the current behaviour for other users of the JOS.ContentSerializer product.

In many of the internal default property handlers, the Handle2 method will just call the original Handle method to make it clear that it doesn't do anything extra. In some cases the functionality have been moved from Handle to a HandleInternal method in order to allow for different settings objects to be used.

All internal implementations of IPropertyHandler will also implement IPropertyHandler2.

The more complex changes are made in the PropertyHandlerService and the PropertyManager. The PropertyManager will now pass the settings object as a parameter if the property handler has a Handler2 method, and the PropertyHandlerService will prioritize old custom IPropertyHandler implementations over new custom IPropertyHandler2 and internal IPropertyHandler2 ones. The default internal Handle method will no longer be used by the code.

The unit tests still tests the original functionality but it should be possible to reuse them for the new implementation when this is consolidated into a single property handler interface and a single handle method again (however, doing so will likely cause breaking changes).

A similar injection issue also exists in the UrlHelperAdapter class, but was left out in order to keep this PR more manageable.